### PR TITLE
Added clang support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,29 +2,30 @@ X11_INCLUDE=/usr/openwin/include
 X11_LIBS=/usr/X11/lib
 X11_LIBS=/usr/openwin/lib
 OBJ=main.o touch.o io.o keyboard.o screen.o terminal.o protocol.o
+CFLAGS=-g -Wno-error=implicit-function-declaration -Wno-error=return-type
 
 all: platoterm
 
 touch.o: touch.c
-	cc -g -I$(X11_INCLUDE) -o $@ -c touch.c
+	cc $(CFLAGS) -I$(X11_INCLUDE) -o $@ -c touch.c
 
 io.o: io.c
-	cc -g -o $@ -c io.c
+	cc $(CFLAGS) -o $@ -c io.c
 
 keyboard.o: keyboard.c
-	cc -g -I$(X11_INCLUDE) -o $@ -c keyboard.c
+	cc $(CFLAGS) -I$(X11_INCLUDE) -o $@ -c keyboard.c
 
 screen.o: screen.c
-	cc -g -I$(X11_INCLUDE) -o $@ -c screen.c
+	cc $(CFLAGS) -I$(X11_INCLUDE) -o $@ -c screen.c
 
 terminal.o: terminal.c
-	cc -g -o $@ -c terminal.c
+	cc $(CFLAGS) -o $@ -c terminal.c
 
 protocol.o: protocol.c
-	cc -g -o $@ -c protocol.c
+	cc $(CFLAGS) -o $@ -c protocol.c
 
 main.o: main.c
-	cc -g -o $@ -c main.c
+	cc $(CFLAGS) -o $@ -c main.c
 
 platoterm: $(OBJ)
 	cc -g -L$(X11_LIBS) -o $@ $(OBJ) -lX11 
@@ -32,5 +33,5 @@ platoterm: $(OBJ)
 clean:
 	rm -rf platoterm $(OBJ)
 
-run:
+check:
 	./platoterm IRATA.ONLINE 8005


### PR DESCRIPTION
- gcc will ignore these options, so you avoid errors like
```
main.c:24:3: error: implicitly declaring library function 'printf' with type 'int (const char *, ...)' [-Werror,-Wimplicit-function-declaration]
                printf("%s <host> <port>\n",argv[0]);
                ^
main.c:24:3: note: include the header <stdio.h> or explicitly provide a declaration for 'printf'
```
- GNU conform target